### PR TITLE
project access key support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/go-chi/httplog v0.3.2
 	github.com/go-chi/jwtauth/v5 v5.3.0
 	github.com/goware/rerun v0.0.9
+	github.com/jxskiss/base62 v1.1.0
 	github.com/lestrrat-go/jwx/v2 v2.0.18
 	github.com/mdlayher/vsock v1.2.1
 	github.com/rs/zerolog v1.31.0
@@ -100,7 +101,7 @@ require (
 	github.com/x448/float16 v0.8.4 // indirect
 	github.com/xanzy/ssh-agent v0.3.3 // indirect
 	golang.org/x/crypto v0.16.0 // indirect
-	golang.org/x/exp v0.0.0-20231206192017-f3f8817b8deb // indirect
+	golang.org/x/exp v0.0.0-20231214170342-aacd6d4b4611 // indirect
 	golang.org/x/mod v0.14.0 // indirect
 	golang.org/x/net v0.19.0 // indirect
 	golang.org/x/sys v0.15.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -203,6 +203,8 @@ github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHW
 github.com/jmespath/go-jmespath/internal/testify v1.5.1 h1:shLQSRRSCCPj3f2gpwzGwWFoC7ycTf1rcQZHOlsJ6N8=
 github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
 github.com/jrick/logrotate v1.0.0/go.mod h1:LNinyqDIJnpAur+b8yyulnQw/wDuN1+BYKlTRt3OuAQ=
+github.com/jxskiss/base62 v1.1.0 h1:A5zbF8v8WXx2xixnAKD2w+abC+sIzYJX+nxmhA6HWFw=
+github.com/jxskiss/base62 v1.1.0/go.mod h1:HhWAlUXvxKThfOlZbcuFzsqwtF5TcqS9ru3y5GfjWAc=
 github.com/kevinburke/ssh_config v0.0.0-20180830205328-81db2a75821e/go.mod h1:CT57kijsi8u/K/BOFA39wgDQJ9CxiF4nAY/ojJ6r6mM=
 github.com/kevinburke/ssh_config v0.0.0-20190725054713-01f96b0aa0cd/go.mod h1:CT57kijsi8u/K/BOFA39wgDQJ9CxiF4nAY/ojJ6r6mM=
 github.com/kevinburke/ssh_config v1.2.0 h1:x584FjTGwHzMwvHx18PXxbBVzfnxogHaAReU4gf13a4=
@@ -333,8 +335,8 @@ golang.org/x/crypto v0.0.0-20220622213112-05595931fe9d/go.mod h1:IxCIyHEi3zRg3s0
 golang.org/x/crypto v0.0.0-20220826181053-bd7e27e6170d/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/crypto v0.16.0 h1:mMMrFzRSCF0GvB7Ne27XVtVAaXLrPmgPC7/v0tkwHaY=
 golang.org/x/crypto v0.16.0/go.mod h1:gCAAfMLgwOJRpTjQ2zCCt2OcSfYMTeZVSRtQlPC7Nq4=
-golang.org/x/exp v0.0.0-20231206192017-f3f8817b8deb h1:c0vyKkb6yr3KR7jEfJaOSv4lG7xPkbN6r52aJz1d8a8=
-golang.org/x/exp v0.0.0-20231206192017-f3f8817b8deb/go.mod h1:iRJReGqOEeBhDZGkGbynYwcHlctCvnjTYIamk7uXpHI=
+golang.org/x/exp v0.0.0-20231214170342-aacd6d4b4611 h1:qCEDpW1G+vcj3Y7Fy52pEM1AWm3abj8WimGYejI3SC4=
+golang.org/x/exp v0.0.0-20231214170342-aacd6d4b4611/go.mod h1:iRJReGqOEeBhDZGkGbynYwcHlctCvnjTYIamk7uXpHI=
 golang.org/x/lint v0.0.0-20201208152925-83fdc39ff7b5/go.mod h1:3xt1FjdF8hUf6vQPIChWIBhFzV8gjjsPE/fR3IyQdNY=
 golang.org/x/mod v0.1.1-0.20191105210325-c90efee705ee/go.mod h1:QqPTAvyqsEbceGzBzNggFXnrqF1CaUcvgkdR5Ot7KZg=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=

--- a/rpc/helpers_test.go
+++ b/rpc/helpers_test.go
@@ -5,6 +5,7 @@ import (
 	"crypto/rand"
 	"crypto/rsa"
 	"encoding/base64"
+	"encoding/binary"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -32,6 +33,7 @@ import (
 	dynamodbtypes "github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
 	"github.com/aws/aws-sdk-go-v2/service/kms"
 	kmstypes "github.com/aws/aws-sdk-go-v2/service/kms/types"
+	"github.com/jxskiss/base62"
 	"github.com/lestrrat-go/jwx/v2/jwa"
 	"github.com/lestrrat-go/jwx/v2/jwk"
 	"github.com/lestrrat-go/jwx/v2/jwt"
@@ -352,6 +354,13 @@ func newSession(t *testing.T, enc *enclave.Enclave, issuer string, wallet *ethwa
 		RefreshedAt:  time.Now(),
 		CreatedAt:    time.Now(),
 	}
+}
+
+func newRandAccessKey(projectID uint64) string {
+	buf := make([]byte, 24)
+	binary.BigEndian.PutUint64(buf, projectID)
+	rand.Read(buf[8:])
+	return base62.EncodeToString(buf)
 }
 
 type walletServiceMock struct{}

--- a/rpc/intents.go
+++ b/rpc/intents.go
@@ -281,17 +281,23 @@ func (s *RPC) signUsingParent(wallet *ethwallet.Wallet, parentAddress common.Add
 	return append(sig, byte(1)), parentSubdigest, nil
 }
 
-func waasContext(ctx context.Context, optAccessToken ...string) (context.Context, error) {
-	var accessToken string
-	if len(optAccessToken) == 1 {
-		accessToken = optAccessToken[0]
+func waasContext(ctx context.Context, optJwtToken ...string) (context.Context, error) {
+	var jwtToken string
+	if len(optJwtToken) == 1 {
+		jwtToken = optJwtToken[0]
 	} else {
 		tntData := tenant.FromContext(ctx)
-		accessToken = tntData.WaasAccessToken
+		jwtToken = tntData.WaasAccessToken
 	}
 
 	waasHeader := http.Header{}
-	waasHeader.Set("authorization", "Bearer "+accessToken)
+	waasHeader.Set("Authorization", "BEARER "+jwtToken)
+
+	accessKey := tenant.AccessKeyFromContext(ctx)
+	if accessKey != "" {
+		waasHeader.Set("X-Access-Key", accessKey)
+	}
+
 	waasCtx, err := proto_wallet.WithHTTPRequestHeaders(ctx, waasHeader)
 	if err != nil {
 		return ctx, err

--- a/rpc/intents_test.go
+++ b/rpc/intents_test.go
@@ -9,7 +9,6 @@ import (
 	mathrand "math/rand"
 	"net/http"
 	"net/http/httptest"
-	"strconv"
 	"testing"
 
 	"github.com/0xsequence/ethkit/ethwallet"
@@ -32,7 +31,7 @@ func TestRPC_GetAddress(t *testing.T) {
 
 	cfg := initConfig(t)
 
-	issuer, tok, closeJWKS := issueAccessTokenAndRunJwksServer(t)
+	issuer, _, closeJWKS := issueAccessTokenAndRunJwksServer(t)
 	defer closeJWKS()
 
 	random := mathrand.New(mathrand.NewSource(42))
@@ -79,8 +78,7 @@ func TestRPC_GetAddress(t *testing.T) {
 
 	c := proto.NewWaasAuthenticatorClient(srv.URL, http.DefaultClient)
 	header := make(http.Header)
-	header.Set("X-Sequence-Tenant", strconv.Itoa(int(tenant.ProjectID)))
-	header.Set("Authorization", "Bearer "+tok)
+	header.Set("X-Access-Key", newRandAccessKey(tenant.ProjectID))
 	ctx, err := proto.WithHTTPRequestHeaders(context.Background(), header)
 
 	addr, err := c.GetAddress(ctx, encryptedPayloadKey, payloadCiphertext, payloadSig)
@@ -95,7 +93,7 @@ func TestRPC_SendIntent_SignMessage(t *testing.T) {
 
 	cfg := initConfig(t)
 
-	issuer, tok, closeJWKS := issueAccessTokenAndRunJwksServer(t)
+	issuer, _, closeJWKS := issueAccessTokenAndRunJwksServer(t)
 	defer closeJWKS()
 
 	random := mathrand.New(mathrand.NewSource(42))
@@ -144,8 +142,7 @@ func TestRPC_SendIntent_SignMessage(t *testing.T) {
 
 	c := proto.NewWaasAuthenticatorClient(srv.URL, http.DefaultClient)
 	header := make(http.Header)
-	header.Set("X-Sequence-Tenant", strconv.Itoa(int(tenant.ProjectID)))
-	header.Set("Authorization", "Bearer "+tok)
+	header.Set("X-Access-Key", newRandAccessKey(tenant.ProjectID))
 	ctx, err := proto.WithHTTPRequestHeaders(context.Background(), header)
 
 	resCode, resData, err := c.SendIntent(ctx, encryptedPayloadKey, payloadCiphertext, payloadSig)
@@ -161,7 +158,7 @@ func TestRPC_SendIntent_SendTransaction(t *testing.T) {
 
 	cfg := initConfig(t)
 
-	issuer, tok, closeJWKS := issueAccessTokenAndRunJwksServer(t)
+	issuer, _, closeJWKS := issueAccessTokenAndRunJwksServer(t)
 	defer closeJWKS()
 
 	random := mathrand.New(mathrand.NewSource(42))
@@ -210,8 +207,7 @@ func TestRPC_SendIntent_SendTransaction(t *testing.T) {
 
 	c := proto.NewWaasAuthenticatorClient(srv.URL, http.DefaultClient)
 	header := make(http.Header)
-	header.Set("X-Sequence-Tenant", strconv.Itoa(int(tenant.ProjectID)))
-	header.Set("Authorization", "Bearer "+tok)
+	header.Set("X-Access-Key", newRandAccessKey(tenant.ProjectID))
 	ctx, err := proto.WithHTTPRequestHeaders(context.Background(), header)
 
 	resCode, resData, err := c.SendIntent(ctx, encryptedPayloadKey, payloadCiphertext, payloadSig)

--- a/rpc/rpc.go
+++ b/rpc/rpc.go
@@ -170,6 +170,7 @@ func (s *RPC) Handler() http.Handler {
 		AllowedOrigins: []string{"https://*"},
 		AllowedMethods: []string{"POST", "OPTIONS"},
 		AllowedHeaders: []string{
+			// TODO: in future we can remove "X-Sequence-Tenant" as its replaced by "X-Access-Key"
 			"Accept", "Authorization", "Content-Type", "X-Attestation-Nonce", "X-Sequence-Tenant", "X-Access-Key",
 		},
 		AllowCredentials: true,

--- a/rpc/sessions_test.go
+++ b/rpc/sessions_test.go
@@ -10,7 +10,6 @@ import (
 	mathrand "math/rand"
 	"net/http"
 	"net/http/httptest"
-	"strconv"
 	"testing"
 
 	"github.com/0xsequence/ethkit/ethwallet"
@@ -85,8 +84,7 @@ func TestRPC_RegisterSession(t *testing.T) {
 
 	c := proto.NewWaasAuthenticatorClient(srv.URL, http.DefaultClient)
 	header := make(http.Header)
-	header.Set("X-Sequence-Tenant", strconv.Itoa(int(tenant.ProjectID)))
-	header.Set("Authorization", "Bearer "+tok)
+	header.Set("X-Access-Key", newRandAccessKey(tenant.ProjectID))
 	ctx, err := proto.WithHTTPRequestHeaders(context.Background(), header)
 	require.NoError(t, err)
 

--- a/rpc/tenant/context.go
+++ b/rpc/tenant/context.go
@@ -8,9 +8,17 @@ import (
 
 type contextKeyType string
 
-var contextKey = contextKeyType("tenant-data")
+var (
+	accessKeyCtxKey = contextKeyType("access-key")
+	tenantCtxKey    = contextKeyType("tenant-data")
+)
 
 func FromContext(ctx context.Context) *proto.TenantData {
-	v, _ := ctx.Value(contextKey).(*proto.TenantData)
+	v, _ := ctx.Value(tenantCtxKey).(*proto.TenantData)
+	return v
+}
+
+func AccessKeyFromContext(ctx context.Context) string {
+	v, _ := ctx.Value(accessKeyCtxKey).(string)
 	return v
 }

--- a/rpc/tenant/middleware.go
+++ b/rpc/tenant/middleware.go
@@ -2,6 +2,7 @@ package tenant
 
 import (
 	"context"
+	"encoding/binary"
 	"fmt"
 	"net/http"
 	"strconv"
@@ -9,16 +10,34 @@ import (
 	"github.com/0xsequence/waas-authenticator/data"
 	"github.com/0xsequence/waas-authenticator/proto"
 	"github.com/0xsequence/waas-authenticator/rpc/crypto"
+	"github.com/jxskiss/base62"
 )
 
-// Middleware validates that the tenant sent in X-Sequence-Tenant header is valid and stores it in context.
+// Middleware validates that the tenant sent in X-Access-Key header is valid and stores it in context.
 func Middleware(tenants *data.TenantTable, tenantKeys []string) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			ctx := r.Context()
 
-			tenantID, _ := strconv.Atoi(r.Header.Get("x-sequence-tenant"))
-			tenant, found, err := tenants.GetLatest(ctx, uint64(tenantID))
+			// Get projectID based on access key header which is encoded in the value
+			// and place the access key on the context.
+			accessKey := r.Header.Get("x-access-key")
+			if accessKey != "" {
+				ctx = context.WithValue(ctx, accessKeyCtxKey, accessKey)
+			}
+			projectID, _ := DecodeProjectIDFromAccessKey(accessKey)
+
+			// For backwards compatibility, we also check the x-seqeunce-tenant
+			// TODO: remove this in the future
+			tid, _ := strconv.Atoi(r.Header.Get("x-sequence-tenant"))
+			tenantID := uint64(tid)
+
+			if projectID > 0 {
+				tenantID = projectID
+			}
+
+			// Find tenant based on project id
+			tenant, found, err := tenants.GetLatest(ctx, tenantID)
 			if err != nil || !found {
 				proto.RespondWithError(w, fmt.Errorf("invalid tenant: %q", tenantID))
 				return
@@ -30,8 +49,16 @@ func Middleware(tenants *data.TenantTable, tenantKeys []string) func(http.Handle
 				return
 			}
 
-			ctx = context.WithValue(ctx, contextKey, tntData)
+			ctx = context.WithValue(ctx, tenantCtxKey, tntData)
 			next.ServeHTTP(w, r.WithContext(ctx))
 		})
 	}
+}
+
+func DecodeProjectIDFromAccessKey(accessKey string) (uint64, error) {
+	buf, err := base62.DecodeString(accessKey)
+	if err != nil || len(buf) < 8 {
+		return 0, fmt.Errorf("invalid access key")
+	}
+	return binary.BigEndian.Uint64(buf[:8]), nil
 }


### PR DESCRIPTION
This PR adds support for Sequence project access keys to waas-authenticator. 

Access keys are used by builder and all other services for project identification (decoding the project id from inside of the access key value), and also passing it along for metering. This value isn't intended to be secure, its just a label.

We deprecate X-Sequence-Tenant header and instead rely on X-Access-Key. Note, we still support X-Sequence-Tenant for backwards compatibility.

In addition, the X-Access-Key is passed to all requests sent to the WaaS API.