### PR TITLE
waas: use original intent to avoid data loss because of outdated struct

### DIFF
--- a/rpc/send_transaction.go
+++ b/rpc/send_transaction.go
@@ -24,7 +24,8 @@ func (s *RPC) sendTransaction(
 		return nil, fmt.Errorf("recovering parent wallet: %w", err)
 	}
 
-	apiIntent := convertToAPIIntent(intent.ToIntent())
+	// use original intent otherwise we may experience lose of data because of outdated struct
+	apiIntent := convertToAPIIntent(&intent.Intent)
 	bundle, err := s.Wallets.GenTransaction(waasContext(ctx), apiIntent)
 	if err != nil {
 		return nil, fmt.Errorf("generating transaction: %w", err)

--- a/rpc/sign_message.go
+++ b/rpc/sign_message.go
@@ -63,7 +63,8 @@ func (s *RPC) signMessage(
 		},
 	}
 
-	apiIntent := convertToAPIIntent(intent.ToIntent())
+	// use original intent otherwise we may experience lose of data because of outdated struct
+	apiIntent := convertToAPIIntent(&intent.Intent)
 	res, err := s.Wallets.SignMessage(waasContext(ctx), apiIntent, signMessage, signatures)
 	if err != nil {
 		return nil, fmt.Errorf("signing message: %w", err)


### PR DESCRIPTION
Since we will not be able to upgrade the authenticator freely we should pass on the original intents to any WaaS APIs. 

Otherwise, if we have outdated e.g. ``IntentDataSendTransaction`` we may experience losing some data and not being able to verify signatures.