### PR TITLE
rpc/signing: don't set Content-Length header

### DIFF
--- a/etc/waas-auth.dev.conf
+++ b/etc/waas-auth.dev.conf
@@ -44,7 +44,7 @@ QwIDAQAB
     region = "ca-central-1"
     source = "noreply@dev-auth.sequence.app"
     source_arn = "arn:aws:ses:ca-central-1:471112647196:identity/sequence.app"
-    access_role_arn = "arn:aws:iam::471112647196:role/dev-mailer-c797a23"
+    access_role_arn = "arn:aws:iam::471112647196:role/dev-mailer"
 
 [builder]
     base_url = "https://dev-api.sequence.build"


### PR DESCRIPTION
The Go server automatically sets `Content-Length` header at the end of response writing. However, this means that the header value is not accessible to the HTTP signature generation middleware. To be able to generate signatures including `Content-Length` as parameter, we would count the response body bytes ourselves and set the header manually.

It worked for as long as the final response matches exactly. However, if an error is returned *after* setting the `Content-Length` header, it's very unlikely that the error response and the expected response have the same length. This causes a mismatch that trips HTTP clients.

This PR doesn't modify the `Content-Length` header, storing its value in a separate variable instead.