### PR TITLE
JWT generation fixes

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -12,13 +12,13 @@ type Config struct {
 	Mode      Mode             `toml:"-"`
 	Region    string           `toml:"region"`
 	Service   ServiceConfig    `toml:"service"`
-	BaseURL   string           `toml:"base_url"`
 	Admin     AdminConfig      `toml:"admin"`
 	Endpoints EndpointsConfig  `toml:"endpoints"`
 	KMS       KMSConfig        `toml:"kms"`
 	SES       SESConfig        `toml:"ses"`
 	Builder   BuilderConfig    `toml:"builder"`
 	Database  DatabaseConfig   `toml:"database"`
+	Signing   SigningConfig    `toml:"signing"`
 	Telemetry telemetry.Config `toml:"telemetry"`
 	Tracing   TracingConfig    `toml:"tracing"`
 }
@@ -65,6 +65,11 @@ type DatabaseConfig struct {
 type BuilderConfig struct {
 	BaseURL  string `toml:"base_url"`
 	SecretID string `toml:"secret_id"`
+}
+
+type SigningConfig struct {
+	Issuer         string `toml:"issuer"`
+	AudiencePrefix string `toml:"audience_prefix"`
 }
 
 type TracingConfig struct {

--- a/etc/waas-auth.dev.conf
+++ b/etc/waas-auth.dev.conf
@@ -49,3 +49,7 @@ QwIDAQAB
 [builder]
     base_url = "https://dev-api.sequence.build"
     secret_id = "dev-builder-jwt"
+
+[signing]
+    issuer = "https://dev-waas.sequence.app"
+    audience_prefix = "https://dev.sequence.build/project/"

--- a/etc/waas-auth.next.conf
+++ b/etc/waas-auth.next.conf
@@ -49,3 +49,7 @@ QwIDAQAB
 [builder]
     base_url = "https://next-api.sequence.build"
     secret_id = "next-builder-jwt"
+
+[signing]
+    issuer = "https://next-waas.sequence.app"
+    audience_prefix = "https://next.sequence.build/project/"

--- a/etc/waas-auth.prod.conf
+++ b/etc/waas-auth.prod.conf
@@ -49,3 +49,7 @@ MQIDAQAB
 [builder]
     base_url = "https://api.sequence.build"
     secret_id = "prod-builder-jwt"
+
+[signing]
+    issuer = "https://waas.sequence.app"
+    audience_prefix = "https://sequence.build/project/"

--- a/etc/waas-auth.sample.conf
+++ b/etc/waas-auth.sample.conf
@@ -7,7 +7,6 @@ region = "us-east-1"
     enclave_port = 9123
     proxy_port = 9124
     debug_profiler = true
-    base_url = "http://localhost:9123"
 
 [telemetry]
     allow_any = true
@@ -52,3 +51,7 @@ QwIDAQAB
 [builder]
     base_url = "http://host.docker.internal:9999"
     secret_id = "BuilderJWT"
+
+[signing]
+    issuer = "http://localhost:9123"
+    audience_prefix = "http://host.docker.internal:9999/project/"

--- a/rpc/identity_provider_test.go
+++ b/rpc/identity_provider_test.go
@@ -44,8 +44,8 @@ func TestRPC_SendIntent_GetIdToken(t *testing.T) {
 
 	srv := httptest.NewServer(svc.Handler())
 	defer srv.Close()
-	svc.Config.BaseURL = srv.URL
-	svc.Config.Builder.BaseURL = "https://sequence.build"
+	svc.Config.Signing.Issuer = srv.URL
+	svc.Config.Signing.AudiencePrefix = "https://sequence.build/project/"
 
 	intentData := &intents.IntentDataGetIdToken{
 		Wallet:    walletAddr,


### PR DESCRIPTION
- Use a separate config section for signing with explicit issuer value and a prefix for the audience value (to which the project ID would be added)
- Configure all environments to use the new config