### PR TITLE
Fix SendIntent error

### DIFF
--- a/rpc/sessions.go
+++ b/rpc/sessions.go
@@ -264,7 +264,7 @@ func (s *RPC) initiateAuth(
 
 		_, err = s.Wallets.InitiateAuth(waasapi.Context(ctx), waasapi.ConvertToAPIIntent(intent.ToIntent()), answer, challenge)
 		if err != nil {
-			return fmt.Errorf("initiating auth with WaaS API: %m", err)
+			return fmt.Errorf("initiating auth with WaaS API: %w", err)
 		}
 
 		encryptedKey, algorithm, ciphertext, err := crypto.EncryptData(ctx, att, tnt.KMSKeys[0], verifCtx)


### PR DESCRIPTION
POST https://dev-waas.sequence.app/rpc/WaasAuthenticator/SendIntent

{
    "error": "WebrpcEndpoint",
    "code": 0,
    "msg": "endpoint error",
    "cause": "initiating auth with WaaS API: {%!m(string=Unauthorized) %!m(int=1000) %!m(string=Unauthorized access) %!m(string=Unauthorized 1000: Unauthorized access: method not allowed for session type) %!m(int=401) %!m(*errors.errorString=\u0026{Unauthorized 1000: Unauthorized access: method not allowed for session type})}",
    "status": 400
}